### PR TITLE
full path & new arguments in submit FP command

### DIFF
--- a/docs/command_line_interface/README.md
+++ b/docs/command_line_interface/README.md
@@ -1034,17 +1034,17 @@ Optional arguments:
 
 </div>
 
-To submit file as false positive (if Imunify360 considers file as a malicious but it actually doesn’t) you can use the following command:
+To submit file as false positive (if Imunify360 considers file as a malicious but it actually doesn’t) you can use the following command (please make sure to specify the file name along with full path):
 
 <div class="notranslate">
 
 ```
-imunify360-agent submit false-positive <file>
+imunify360-agent submit false-positive --reason <reason> --scanner ai-bolit <file>
 ```
 
 </div>
 
-To submit file as false negative (if Imunify360 considers file as a non-malicious but it actually does) you can use the following command:
+To submit file as false negative (if Imunify360 considers file as a non-malicious but it actually does) you can use the following command (please make sure to specify the file name along with full path):
 
 <div class="notranslate">
 


### PR DESCRIPTION
1) added
 (please make sure to specify the file name along with full path)
in two places, near
imunify360-agent submit false-positive
imunify360-agent submit false-negative
commands (ppl often don't realize that full path is a must and receive errors trying to submit just file names)

2) added two new mandatory arguments
--reason <reason> --scanner ai-bolit
to the
imunify360-agent submit false-positive
command - previously they were not mandatory
(besides ai-bolit, there is a "clamav" argument for --scanner, but we aren't using it)