### PR TITLE
Update README.md

### DIFF
--- a/docs/dashboard/README.md
+++ b/docs/dashboard/README.md
@@ -525,7 +525,12 @@ You will see the _Scope_ column and controls (on clicking the _Add_ button) to m
 
 #### How to change Scope to Group/Local
 
-To change the scope to <span class="notranslate">_Group/Local_</span>, go to <span class="notranslate">_Firewall > White/Black list_</span> and select an IP.
+To change the scope to <span class="notranslate">_Group/Local_</span>, first create your groups in the CLN.
+
+![](https://blog.imunify360.com/hubfs/pasted%20image%200%20(1)-1.png)
+
+
+After that, go to <span class="notranslate">_Firewall > White/Black list_</span> and select an IP.
 
 
 * In the <span class="notranslate">_Actions_</span> column click ![](/images/gear.png).


### PR DESCRIPTION
as per https://trello.com/c/6eUEegPs/57-89305-lack-of-info-about-groups-scope - at https://docs.imunify360.com/dashboard/#how-to-change-scope-to-group-local and nowhere in the docs it says that it is necessary to create a group in the CLN before it starts showing up in the UI, so at least one user attempted finding them having not actually created them, and thus lack of that step makes it a bit misleading