### PR TITLE
Add supported apache versions for Stand-alone

### DIFF
--- a/docs/stand_alone/README.md
+++ b/docs/stand_alone/README.md
@@ -19,7 +19,7 @@ Imunify360 can be installed directly on the server, independent of any panel, re
 
 **Web servers**
 
-* Apache
+* Apache >= 2.4.30
 * LiteSpeed
 * Nginx (starting from Imunify360 5.4)
 


### PR DESCRIPTION
It is necessary to add missing supported apache versions for Stand-alone.