### PR TITLE
correct typo for CLI docs (whitest command)

### DIFF
--- a/docs/command_line_interface/README.md
+++ b/docs/command_line_interface/README.md
@@ -2054,7 +2054,7 @@ where `12.34.56.78` is that specific IP address.
 <div class="notranslate">
 
    ```
-   imunify360-agent whitelist ip add 1.2.3.4 --comment “one good ip”
+   imunify360-agent whitelist ip add 1.2.3.4 --comment "one good ip"
    OK
    ```
 

--- a/docs/command_line_interface/README.md
+++ b/docs/command_line_interface/README.md
@@ -2049,7 +2049,7 @@ where `12.34.56.78` is that specific IP address.
 
 **Examples:**
 
-1. The following commands adds IP `1.2.3.4` to the <span class="notranslate">White List</span> with a comment <span class="notranslate">“one bad ip”</span>:
+1. The following commands adds IP `1.2.3.4` to the <span class="notranslate">White List</span> with a comment <span class="notranslate">“one good ip”</span>:
 
 <div class="notranslate">
 


### PR DESCRIPTION
We receive feedback from a customer suggesting the correction of the typo:
"The first example on https://docs.imunify360.com/command_line_interface/#whitelist is having a small but confusing typo.
I suggest changing the first comment "one bad ip" to "one good ip"."