### PR TITLE
stand_alone: modsec_domain_config_script key belongs to integration_scripts

### DIFF
--- a/docs/stand_alone/README.md
+++ b/docs/stand_alone/README.md
@@ -178,7 +178,7 @@ To enable domain-specific ModSecurity configuration, specify the <span class="no
 <div class="notranslate">
 
 ``` ini
-[web_server]
+[integration_scripts]
 modsec_domain_config_script = /path/to/inject/domain/specific/config/script.sh
 ```
 </div>


### PR DESCRIPTION
stand_alone: modsec_domain_config_script key belongs to integration_scripts, not web_server