### PR TITLE
Explicitly set filename for force-update script

### DIFF
--- a/docs/update/README.md
+++ b/docs/update/README.md
@@ -13,7 +13,7 @@ If you do not want to wait for the gradual roll-out, you can update Imunify360 t
 <div class="notranslate">
 
 ```
-wget https://repo.imunify360.cloudlinux.com/defence360/imunify-force-update.sh
+wget -O imunify-force-update.sh https://repo.imunify360.cloudlinux.com/defence360/imunify-force-update.sh
 bash imunify-force-update.sh
 ```
 </div>


### PR DESCRIPTION
To avoid creating a new file with numbers in the name, if the old script is already present in the folder. This may confuse the users, they may run wrong script.

```
# ls -l imunify-force-update.sh*
-rw-r--r-- 1 root root 1849 Jun  8  2021 imunify-force-update.sh
-rw-r--r-- 1 root root 1877 Jan 27 03:39 imunify-force-update.sh.1
```